### PR TITLE
aria2c命令行增加超时和重试设置

### DIFF
--- a/chrome/src/core.js
+++ b/chrome/src/core.js
@@ -465,7 +465,7 @@ var CORE = (function() {
                     var length = file_list.length;
                     for (var i = 0; i < length; i++) {
                         var filename = (navigator.platform.indexOf("Win") != -1) ? JSON.stringify(file_list[i].name) : CORE.escapeString(file_list[i].name);
-                        files.push("aria2c -c -s10 -k1M -x16 --enable-rpc=false -o " + filename + CORE.getHeader("aria2c_line") + " " + JSON.stringify(file_list[i].link) + "\n");
+                        files.push("aria2c -c -s10 -k1M -x16 -t1 -m0 --enable-rpc=false -o " + filename + CORE.getHeader("aria2c_line") + " " + JSON.stringify(file_list[i].link) + "\n");
                         aria2c_txt.push([
                             file_list[i].link,
                             CORE.getHeader("aria2c_txt"),


### PR DESCRIPTION
最近 baidu 似乎会下载者就丢速度到0，把超时设置成1秒，重试次数设置成无限次，这样速度可以稳定在2M。